### PR TITLE
Ensure anchors from included YAML are indexed

### DIFF
--- a/cardan.go
+++ b/cardan.go
@@ -97,6 +97,11 @@ func LoadWithOptions(r io.Reader, opts LoadOptions) (*Doc, error) {
 		if err := resolveIncludes(doc.RawTree, opts.BasePath, opts.IncludeTag, visited); err != nil {
 			return nil, err
 		}
+		// re-index anchors after processing includes
+		doc.NodesByID = make(map[string]*Node)
+		if err := indexNodes(doc, doc.RawTree.Content); err != nil {
+			return nil, err
+		}
 	}
 
 	return doc, nil

--- a/cardan_test.go
+++ b/cardan_test.go
@@ -142,6 +142,28 @@ func TestLoadWithIncludes_DenySyntacticTraversal(t *testing.T) {
 	}
 }
 
+func TestLoadWithIncludes_AnchorIndexed(t *testing.T) {
+	base := "testdata/include_anchor"
+	mainPath := filepath.Join(base, "main.yml")
+	r, err := os.Open(mainPath)
+	if err != nil {
+		t.Fatalf("failed to open main.yml: %v", err)
+	}
+	defer r.Close()
+
+	doc, err := LoadWithOptions(r, LoadOptions{
+		IncludeTag: "!include",
+		BasePath:   base,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error loading with includes: %v", err)
+	}
+
+	if _, ok := doc.NodesByID["inc_anchor"]; !ok {
+		t.Fatalf("expected anchor from included file to be indexed")
+	}
+}
+
 // === HELPERS ===
 
 func parseTestDoc(t *testing.T, filename string) *Doc {

--- a/testdata/include_anchor/included.yml
+++ b/testdata/include_anchor/included.yml
@@ -1,0 +1,2 @@
+settings: &inc_anchor
+  retries: 2

--- a/testdata/include_anchor/main.yml
+++ b/testdata/include_anchor/main.yml
@@ -1,0 +1,1 @@
+config: !include included.yml


### PR DESCRIPTION
## Summary
- add fixture to test include files containing anchors
- reindex anchors in `LoadWithOptions` after resolving includes
- add `TestLoadWithIncludes_AnchorIndexed` to verify anchor presence

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865c62cf9f4832f815e4e02327f8436