### PR TITLE
Fix README import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/theraccoonbear/cardan"
+	"github.com/theraccoonbear/CarDan"
 )
 
 type Job struct {


### PR DESCRIPTION
## Summary
- fix the example import path to reference `CarDan`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865c627e3bc832f8d12210161731c77