### PR TITLE
Handle anchors after include

### DIFF
--- a/cardan_test.go
+++ b/cardan_test.go
@@ -142,6 +142,37 @@ func TestLoadWithIncludes_DenySyntacticTraversal(t *testing.T) {
 	}
 }
 
+func TestLoadWithIncludes_IndexAnchors(t *testing.T) {
+	base := "testdata/include_anchor"
+	mainPath := filepath.Join(base, "main.yml")
+	r, err := os.Open(mainPath)
+	if err != nil {
+		t.Fatalf("failed to open main.yml: %v", err)
+	}
+	defer r.Close()
+
+	doc, err := LoadWithOptions(r, LoadOptions{
+		IncludeTag: "!include",
+		BasePath:   base,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error loading with includes: %v", err)
+	}
+
+	if _, ok := doc.NodesByID["extra"]; !ok {
+		t.Fatal("expected anchor 'extra' from included file")
+	}
+
+	dup, ok := doc.NodesByID["dup"]
+	if !ok {
+		t.Fatalf("expected anchor 'dup' from main file not found")
+	}
+	name := findMapEntry(dup.AST, "name")
+	if name == nil || name.Value != "main" {
+		t.Fatalf("anchor 'dup' should reference main file value 'main', got %v", name)
+	}
+}
+
 // === HELPERS ===
 
 func parseTestDoc(t *testing.T, filename string) *Doc {

--- a/testdata/include_anchor/included.yml
+++ b/testdata/include_anchor/included.yml
@@ -1,0 +1,4 @@
+includedJob: &dup
+  name: included
+extraJob: &extra
+  name: extra

--- a/testdata/include_anchor/main.yml
+++ b/testdata/include_anchor/main.yml
@@ -1,0 +1,3 @@
+mainJob: &dup
+  name: main
+include: !include included.yml


### PR DESCRIPTION
## Summary
- keep original anchors when reindexing
- re-index anchors after resolving includes
- verify anchors from included YAML

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865c60d5adc832f9c5e19a0882e2d32